### PR TITLE
Add messaging classes to test communication between modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -991,6 +991,11 @@
         "es5-ext": "0.10.38"
       }
     },
+    "eventemitter3": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.0.tgz",
+      "integrity": "sha512-62TxCtz4m2LRaOERVEvLJJ4A6rsg8lC9Xm+FLg2y/1fB/v4ZZ9JCOn+/Ppl5KkH6sRih6bhix724PVanmXYZJQ=="
+    },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "webpack": "^3.10.0"
   },
   "dependencies": {
-    "underscore": "^1.6.0"
+    "underscore": "^1.6.0",
+    "eventemitter3": "^3.0.0"
   }
 }

--- a/server/displayControl.js
+++ b/server/displayControl.js
@@ -1,11 +1,9 @@
-console.log("Someday I'll be the display control module");
-
-const moduleName = 'display-control';
+const moduleName = 'displayControl';
 let displayId = null;
 
 self.onmessage = (event) => {
     const message = event.data;
-    console.log(`Display control module received message: ${JSON.stringify(message)}`);
+    console.log(`${moduleName} - received message: ${JSON.stringify(message)}`);
     if (message.from === 'installer' && message.topic === 'startup') {
         displayId = message.displayId;
         run();
@@ -25,5 +23,6 @@ function sendWatchMessage() {
 }
 
 function run() {
+    console.log(`${moduleName} - started`);
     sendWatchMessage();
 }

--- a/server/displayControl.js
+++ b/server/displayControl.js
@@ -25,4 +25,13 @@ function sendWatchMessage() {
 function run() {
     console.log(`${moduleName} - started`);
     sendWatchMessage();
+    logExternal('started');
+}
+
+function logExternal(event) {
+    self.postMessage({
+        from: moduleName,
+        topic: "log",
+        data: {event}
+    });
 }

--- a/server/logging.js
+++ b/server/logging.js
@@ -1,1 +1,21 @@
-console.log("Someday I'll be the logging module");
+const moduleName = 'logging';
+
+self.onmessage = (event) => {
+    const message = event.data;
+    console.log(`${moduleName} - received message: ${JSON.stringify(message)}`);
+    if (message.from === 'installer' && message.topic === 'startup') {
+        run();
+    } else {
+        handleLogMessage(message)
+    }
+}
+
+function handleLogMessage(message) {
+    if (message.topic === "log") {
+        console.log(`${moduleName} - call logger to log ${message}`);
+    }
+}
+
+function run() {
+    console.log(`${moduleName} - started`);
+}

--- a/server/messaging.js
+++ b/server/messaging.js
@@ -1,7 +1,0 @@
-const channel = new BroadcastChannel('local-messaging-module')
-
-channel.onmessage = function(e) {
-  console.log('Local messaging received', e.data);
-};
-
-channel.postMessage('Local messaging has started');

--- a/server/twitter.js
+++ b/server/twitter.js
@@ -1,0 +1,41 @@
+const moduleName = 'twitter';
+let displayId = null;
+
+self.onmessage = (event) => {
+    const message = event.data;
+    console.log(`${moduleName} - received message: ${JSON.stringify(message)}`);
+    if (message.from === 'installer' && message.topic === 'startup') {
+        displayId = message.displayId;
+        run();
+    } else {
+        handleMessage(message);
+    }
+}
+
+function handleMessage(message) {
+    console.log(`${moduleName} - handleMessage ${JSON.stringify(message)}`);
+}
+
+function sendTweets() {
+    setInterval(() => {
+        self.postMessage({
+            from: moduleName,
+            topic: "twitter-update",
+            data: {id: 1234, text: "blabla"}
+        });
+    }, 4000);
+}
+
+function run() {
+    console.log(`${moduleName} - started`);
+    sendTweets();
+    logExternal('started');
+}
+
+function logExternal(event) {
+    self.postMessage({
+        from: moduleName,
+        topic: "log",
+        data: {event}
+    });
+}

--- a/src/background.js
+++ b/src/background.js
@@ -31,7 +31,8 @@ function init(launchData) {
         messaging: 'https://raw.githubusercontent.com/Rise-Vision/chrome-os-player-poc/master/server/messaging.js',
         logging: 'https://raw.githubusercontent.com/Rise-Vision/chrome-os-player-poc/master/server/logging.js',
         watchdog: 'https://raw.githubusercontent.com/Rise-Vision/chrome-os-player-poc/master/server/watchdog.js',
-        displayControl: 'https://raw.githubusercontent.com/Rise-Vision/chrome-os-player-poc/master/server/displayControl.js'
+        displayControl: 'https://raw.githubusercontent.com/Rise-Vision/chrome-os-player-poc/master/server/displayControl.js',
+        twitter: 'https://raw.githubusercontent.com/Rise-Vision/chrome-os-player-poc/master/server/twitter.js'
     };
 
     const channel = new BroadcastChannel('local-messaging-module');

--- a/src/filesystem.js
+++ b/src/filesystem.js
@@ -84,6 +84,17 @@ const FileSystem = {
         return this.getDirectory(fs, name, true);
     },
 
+    removeDirectory(name) {
+        return this.requestFileSystem()
+            .then((fs) => this.getDirectory(fs, name))
+            .then((dirEntry) => {
+                return new Promise((resolve, reject) => {
+                    dirEntry.removeRecursively(resolve, reject);
+                });
+            })
+            .catch(() => Promise.resolve());
+    },
+
     listEntries(dirName = 'modules') {
         return this.requestFileSystem()
             .then((fs) => this.getDirectory(fs, dirName, true))

--- a/src/installer.js
+++ b/src/installer.js
@@ -12,6 +12,9 @@ class RemoteModule {
         this.worker = worker;
         this.messagingClient = messagingClient;
         this.worker.addEventListener('message', this.handleWorkerMessage.bind(this));
+        this.messagingClient.receiveMessages((receiver) => {
+            receiver.on('message', this.handleLocalMessage.bind(this));
+        });
     }
 
     postMessage(message) {
@@ -24,8 +27,15 @@ class RemoteModule {
     }
 
     handleWorkerMessage(message) {
-        console.log(`${this.constructor.name} - Message received from ${this.name} - ${JSON.stringify(message.data)}`);
+        console.log(`${this.constructor.name} ${this.name} - Handling worker message - ${JSON.stringify(message.data)}`);
         this.messagingClient.broadcastMessage(message.data);
+    }
+
+    handleLocalMessage(message) {
+        console.log(`${this.constructor.name} ${this.name} - Handling local message - ${JSON.stringify(message.data)}`);
+        if (message.from !== this.name) {
+            this.worker.postMessage(message);
+        }
     }
 }
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -1,6 +1,33 @@
 import FileSystem from './filesystem'
+import LocalStorageModule from './modules/local-storage'
+import messaging from './messaging'
 
-const installedModules = [];
+const packagedModules = [new LocalStorageModule()];
+const remoteModules = [];
+
+class RemoteModule {
+
+    constructor(name, worker, messagingClient) {
+        this.name = name;
+        this.worker = worker;
+        this.messagingClient = messagingClient;
+        this.worker.addEventListener('message', this.handleWorkerMessage.bind(this));
+    }
+
+    postMessage(message) {
+        this.worker.postMessage(message);
+    }
+
+    shutdown() {
+        console.log(`${this.constructor.name} - shutdown ${this.name}`);
+        this.worker.terminate();
+    }
+
+    handleWorkerMessage(message) {
+        console.log(`${this.constructor.name} - Message received from ${this.name} - ${JSON.stringify(message.data)}`);
+        this.messagingClient.broadcastMessage(message.data);
+    }
+}
 
 function saveModuleFile(name, response) {
     return FileSystem.saveFile(name, response.body);
@@ -15,14 +42,10 @@ function loadModuleScript(name, fileUrl) {
 
 function loadModuleAsWorker(name, fileUrl) {
     const worker = new Worker(fileUrl);
-    worker.postMessage({from: 'installer', topic: 'startup'});
-    worker.addEventListener('message', handleWorkerMessage)
-    installedModules.push(worker);
-    return name;
-}
-
-function handleWorkerMessage(message) {
-    console.log(`Message received ${JSON.stringify(message.data)}`);
+    return messaging.connect(name).then((client) => {
+        remoteModules.push(new RemoteModule(name, worker, client));
+        return name;
+    });
 }
 
 function loadModuleAsScriptTag(name, fileUrl) {
@@ -38,24 +61,30 @@ function loadModuleAsScriptTag(name, fileUrl) {
 }
 
 function uninstallModules() {
-    installedModules.forEach(worker => {
-        worker.terminate();
+    remoteModules.forEach(module => {
+        module.shutdown();
     });
     return Promise.resolve();
 }
 
 function initModule(name, url) {
     return fetch(url)
-        .then(response => saveModuleFile(name, response))
+        .then(response => saveModuleFile(`${name}.js`, response))
         .then(fileUrl => loadModuleScript(name, fileUrl))
 }
 
-function installModules(modules) {
-    const funcs = Object.keys(modules).map(moduleName => () => initModule(`${moduleName}.js`, modules[moduleName]))
-    const installModulesPromises = serialPromises(funcs);
+function initModules() {
+    packagedModules.forEach(module => module.init());
+    remoteModules.forEach(module => module.postMessage({from: 'installer', topic: 'startup'}));
+}
 
+function installModules(modules) {
     return uninstallModules()
-        .then(installModulesPromises)
+        .then(() => {
+            const promises = Object.keys(modules).map(moduleName => initModule(moduleName, modules[moduleName]))
+            return serialPromises(promises);
+        })
+        .then(() => initModules())
         .then(() => FileSystem.listEntries())
         .then((entries) => {
             console.log('All modules have been loaded from manifest:');
@@ -66,8 +95,12 @@ function installModules(modules) {
         .catch(console.error);
 }
 
-function serialPromises(funcs) {
-    return funcs.reduce((promise, func) => promise.then(result => func().then(Array.prototype.concat.bind(result))), Promise.resolve([]));
+function serialPromises(tasks) {
+    return tasks.reduce((promiseChain, currentTask) => {
+        return promiseChain.then(chainResults =>
+            currentTask.then(currentResult => [...chainResults, currentResult])
+        );
+    }, Promise.resolve([]))
 }
 
 const Installer = {installModules}

--- a/src/main.js
+++ b/src/main.js
@@ -54,7 +54,7 @@ function openLink(e) {
         'webview.html',
         {hidden: true},
         (appWin) => {
-            appWin.contentWindow.addEventListener('DOMContentLoaded', (e) => {
+            appWin.contentWindow.addEventListener('DOMContentLoaded', () => {
                 let tag = 'p';
                 if (type.startsWith('image')) {
                     tag = 'img';

--- a/src/messaging.js
+++ b/src/messaging.js
@@ -32,7 +32,7 @@ class MessagingClient {
         const receiver = new EventEmitter();
         this.bus.on('message', (message) => {
             console.log(`${this.constructor.name} ${this.moduleName} - got a message: ${JSON.stringify(message)}`);
-            receiver.emit("message", message);
+            receiver.emit('message', message);
         });
         return receiver;
     }
@@ -60,10 +60,7 @@ class Messaging {
     }
 
     broadcastMessage(message) {
-        console.log(`${this.constructor.name} - broadcastMessage(${message})`);
-        this.clientList.forEach((client) => {
-            client.broadcastMessage(message);
-        });
+        this.bus.emit(message);
         return Promise.resolve();
     }
 

--- a/src/messaging.js
+++ b/src/messaging.js
@@ -1,0 +1,108 @@
+import EventEmitter from 'eventemitter3'
+
+class MessagingClient {
+
+    constructor(moduleName, bus) {
+        this.moduleName = moduleName;
+        this.bus = bus;
+    }
+
+    broadcastMessage(message) {
+        console.log(`${this.constructor.name} ${this.moduleName} - broadcastMessage(${message})`);
+        this.bus.emit('message', message);
+    }
+
+    getClientList() {
+        console.log(`${this.constructor.name} ${this.moduleName} - getClientList()`);
+        this.bus.emit('clientlist-request');
+    }
+
+    toMessagingService(message) {
+        console.log(`${this.constructor.name} ${this.moduleName} - toMessagingService(${message})`);
+        this.bus.emit("message", Object.assign({}, message, {through: "ms"}));
+    }
+
+    toLocalWS(message) {
+        console.log(`${this.constructor.name} ${this.moduleName} - toLocalWS(${message})`);
+        this.bus.emit("message", Object.assign({}, message, {through: "ws"}));
+    }
+
+    receiveMessages() {
+        console.log(`${this.constructor.name} ${this.moduleName} - receiveMessages()`);
+        const receiver = new EventEmitter();
+        this.bus.on('message', (message) => {
+            console.log(`${this.constructor.name} ${this.moduleName} - got a message: ${JSON.stringify(message)}`);
+            receiver.emit("message", message);
+        });
+        return receiver;
+    }
+}
+
+class Messaging {
+
+    constructor() {
+        this.clientList = [];
+        this.bus = new EventEmitter();
+    }
+
+    connect(moduleName) {
+        console.log(`${this.constructor.name} - connect(${moduleName})`);
+        const client = new MessagingClient(moduleName, this.bus);
+        this.clientList.push(client);
+        return Promise.resolve(client);
+    }
+
+    disconnect() {
+        console.log(`${this.constructor.name} - disconnect()`);
+        this.clientList = [];
+        // broadcast disconnect?
+        return Promise.resolve();
+    }
+
+    broadcastMessage(message) {
+        console.log(`${this.constructor.name} - broadcastMessage(${message})`);
+        this.clientList.forEach((client) => {
+            client.broadcastMessage(message);
+        });
+        return Promise.resolve();
+    }
+
+    broadcastToLocalWS(message) {
+        console.log(`${this.constructor.name} - broadcastToLocalWS(${message})`);
+        this.clientList.forEach((client) => {
+            client.toLocalWS(message);
+        });
+        return Promise.resolve();
+    }
+
+    getClientList(moduleName) {
+        console.log(`${this.constructor.name} - getClientList()`);
+        const moduleClient = this.clientList.find(client => client.moduleName === moduleName);
+        if (moduleClient) {
+            moduleClient.getClientList();
+        }
+        return Promise.resolve(moduleClient);
+    }
+
+    sendToMessagingService(message) {
+        console.log(`${this.constructor.name} - sendToMessagingService(${message})`);
+        const moduleClient = this.clientList.find(client => client.moduleName === message.from);
+        if (moduleClient) {
+            moduleClient.toMessagingService(message);
+        }
+        return Promise.resolve(moduleClient);
+    }
+
+    receiveMessages(moduleName) {
+        console.log(`${this.constructor.name} - receiveMessages(${moduleName})`);
+        const moduleClient = this.clientList.find(client => client.moduleName === moduleName);
+        if (moduleClient) {
+            // heartbeat.startHeartbeatInterval(moduleName);
+            return Promise.resolve(moduleClient.receiveMessages());
+        }
+        return this.connect(moduleName).then(client => client.receiveMessages());
+    }
+
+}
+
+export default new Messaging();

--- a/src/modules/local-storage.js
+++ b/src/modules/local-storage.js
@@ -1,8 +1,8 @@
-import Messaging from '../messaging'
+import messaging from '../messaging'
 
 export default class LocalStorageModule {
     init() {
-        return Messaging.receiveMessages('localStorage').then(receiver => {
+        return messaging.receiveMessages('localStorage').then(receiver => {
             receiver.on('message', this.handleMessage.bind(this));
         })
     }

--- a/src/modules/local-storage.js
+++ b/src/modules/local-storage.js
@@ -1,0 +1,7 @@
+import Messaging from '../messaging'
+
+export default class LocalStorageModule {
+    init() {
+        return Messaging.receiveMessages('localStorage')
+    }
+}

--- a/src/modules/local-storage.js
+++ b/src/modules/local-storage.js
@@ -2,6 +2,12 @@ import Messaging from '../messaging'
 
 export default class LocalStorageModule {
     init() {
-        return Messaging.receiveMessages('localStorage')
+        return Messaging.receiveMessages('localStorage').then(receiver => {
+            receiver.on('message', this.handleMessage.bind(this));
+        })
+    }
+
+    handleMessage(message) {
+        console.log(`${this.constructor.name} - handleMessage(${JSON.stringify(message)})`);
     }
 }


### PR DESCRIPTION
Created `Messaging` class to mimic the existing ipc messaging protocol:

  * There's a singleton `EventEmitter` as a message bus
  * There's a global list of modules and for each of them a messaging client that implements the existing interface
  * For remote modules, there's a `RemoteModule` class that acts as an adapter of the web workers messages to the local messaging bus

Created `LocalStorageModule` class to simulate a packaged module.