### PR TITLE
PoC for retrieving available disk space

### DIFF
--- a/src/filesystem.js
+++ b/src/filesystem.js
@@ -120,6 +120,26 @@ const FileSystem = {
                 processChunkedContents(contents, fileWriter).then(resolve).catch(reject);
             });
         });
+    },
+
+    bytesToSize(bytes) {
+        const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
+        if (bytes === 0) { return "n/a"; }
+
+        const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)), 10);
+        if (i === 0) return `${bytes} ${sizes[i]})`;
+        return `${(bytes / (1024 ** i)).toFixed(1)} ${sizes[i]}`;
+    },
+
+    getAvailableDiskSpace(cb) {
+        navigator.webkitPersistentStorage.queryUsageAndQuota (
+            function(usedBytes, grantedBytes) {
+                cb(usedBytes, grantedBytes);
+            },
+            function(err) {
+                cb(null,null,err);
+            }
+        );
     }
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -160,6 +160,16 @@ function testMSClientSocket() {
         })
 }
 
+function testAvailableDiskSpace() {
+    FileSystem.getAvailableDiskSpace((usedBytes, grantedBytes, err)=>{
+        if (err) {
+           console.log(`Error: ${err}`);
+           return;
+        }
+        writeToOutput(`App is using ${FileSystem.bytesToSize(usedBytes)} of ${FileSystem.bytesToSize(grantedBytes)} available disk space`);
+    });
+}
+
 function init() {
     output = document.querySelector('output');
 
@@ -170,7 +180,10 @@ function init() {
         console.log(launchData);
         // FileSystem.kioskMode = launchData.isKioskSession;
 
-        readLargeFilesDir().then(testSavingLargeFiles).then(()=>{testMSClientSocket();});
+        readLargeFilesDir().then(testSavingLargeFiles).then(()=>{
+            // testMSClientSocket();
+            testAvailableDiskSpace();
+        });
     });
 }
 


### PR DESCRIPTION
- manifest.json must set `unlimitedStorage` in permissions
- check persistent storage via HTML5 Offline API - `navigator.webkitPersistentStorage.queryUsageAndQuota()`, provides used storage by the app and the available space left