### PR TITLE
Adding test for offline play

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -18,6 +18,7 @@
         <label for="url">URL:</label>
         <input id="url" type="text" style="width: 300px"></input>
         <button id="saveFile">Save File</button>
+        <button id="launchWebView">Launch WebView</button>
     </form>
     <label>Existing files:</label>
     <ul id="files"></ul>

--- a/app/webview.html
+++ b/app/webview.html
@@ -5,6 +5,5 @@
 </head>
 <body>
   <webview partition="persist:trusted"></webview>
-  <iframe></iframe>
 </body>
 </html>

--- a/server/offline-test/index.html
+++ b/server/offline-test/index.html
@@ -7,5 +7,6 @@
 </head>
 <body>
     <h1>Chrome Player Offline - PoC</h1>
+    <img src="http://localhost:8080/rise.jpg"></img>
 </body>
 </html>

--- a/server/offline-test/index.html
+++ b/server/offline-test/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Rise Vision Offline Viewer - PoC</title>
+    <script src="main.js"></script>
+</head>
+<body>
+    <h1>Chrome Player Offline - PoC</h1>
+</body>
+</html>

--- a/server/offline-test/main.js
+++ b/server/offline-test/main.js
@@ -1,0 +1,26 @@
+function registerServiceWorker() {
+    if (!('serviceWorker' in navigator)) {
+        console.log('Service worker not supported');
+        return;
+    }
+
+    return navigator.serviceWorker.register('sw.js')
+        .then(() => {
+            console.log('Registered');
+        })
+        .catch((error) => {
+            console.log('Registration failed:', error);
+        });
+}
+
+registerServiceWorker()
+    .then(() => {
+        return fetch('http://localhost:8080/ten_mega.png');
+    })
+    .then(response => response.blob())
+    .then((blob) => {
+        const url = URL.createObjectURL(blob);
+        const image = new Image();
+        image.src = url;
+        document.body.appendChild(image);
+    });

--- a/server/offline-test/sw.js
+++ b/server/offline-test/sw.js
@@ -1,0 +1,59 @@
+const CACHE = 'offline-viewer-poc';
+
+const staticContent = [
+    '/rise-andre/offline-test/index.html',
+    '/rise-andre/offline-test/main.js'
+];
+
+function precache() {
+    return caches.open(CACHE).then((cache) => {
+        return cache.addAll(staticContent);
+    });
+}
+
+function fromCache(request) {
+    return caches.open(CACHE).then((cache) => {
+        return cache.match(request).then((matching) => {
+            return matching || Promise.reject(new Error('no-match'));
+        });
+    });
+}
+
+function fromNetwork(request, timeout) {
+    return new Promise((resolve, reject) => {
+        const timeoutId = setTimeout(reject, timeout);
+        fetch(request).then((response) => {
+            clearTimeout(timeoutId);
+            resolve(response);
+        }, reject);
+    });
+}
+
+self.addEventListener('install', (event) => {
+    console.log('Service worker installing...');
+    console.log(event);
+    event.waitUntil(precache());
+});
+
+self.addEventListener('activate', (event) => {
+    console.log('Service worker activating...');
+    console.log(event);
+});
+
+self.addEventListener('push', (event) => {
+    console.log('Service worker push...');
+    console.log(event);
+});
+
+self.addEventListener('sync', (event) => {
+    console.log('Service worker sync...');
+    console.log(event);
+});
+
+self.addEventListener('fetch', (event) => {
+    console.log('Service worker fetch...');
+    console.log(event);
+    event.respondWith(fromNetwork(event.request, 400).catch(() => {
+        return fromCache(event.request);
+    }));
+});

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ function openLink(e) {
                     video.src = url;
                     appWin.contentWindow.document.body.appendChild(video);
                 } else if (type.startsWith('text/html')) {
-                    const webview = appWin.contentWindow.document.querySelector('iframe');
+                    const webview = appWin.contentWindow.document.querySelector('webview');
                     webview.src = url;
                 }
 
@@ -121,6 +121,11 @@ function launchViewer(event) {
         viewerUrl = chrome.runtime.getURL(`local-viewer/viewer/localviewer/main/Viewer.html?player=true&type=display&id=${displayId}`);
     }
 
+    createViewerWindowWithUrl(viewerUrl);
+}
+
+function createViewerWindowWithUrl(url) {
+    console.log(`creating viewer window with url: ${url}`);
     getWindowOptions().then((windowOptions) => {
         chrome.app.window.create(
             'viewer.html',
@@ -131,7 +136,8 @@ function launchViewer(event) {
                     webview.addEventListener('permissionrequest', handleViewerWebViewPermissions);
                     webview.style.height = `${windowOptions.height}px`;
                     webview.style.width = '100%';
-                    webview.src = viewerUrl;
+                    console.log(`loading webview with url: ${url}`);
+                    webview.src = url;
                     appWin.show();
                 }
             );
@@ -206,6 +212,16 @@ function init() {
         });
     });
 
+    const launchWebViewButton = document.getElementById('launchWebView');
+    launchWebViewButton.addEventListener('click', (event) => {
+        const url = document.getElementById('url').value;
+        if (!url) {
+            return;
+        }
+        event.preventDefault();
+        createViewerWindowWithUrl(url);
+    });
+
     chrome.storage.local.get("launchData", ({launchData}) => {
         console.log(launchData);
         // FileSystem.kioskMode = launchData.isKioskSession;
@@ -230,6 +246,7 @@ function startWebServer() {
                 renderIndex: false,
                 optBackground: false,
                 optAutoStart: false,
+                optCORS: true,
                 port: 8080
             };
             webServer = new WSC.WebApplication(options);


### PR DESCRIPTION
Files under `server/offline-test` are deployed at https://storage.googleapis.com/rise-andre/offline-test/index.html and can be loaded on a webview consuming a previously downloaded local file that is served through the local http server running on the chrome app